### PR TITLE
Feature/adding resolvers for users tweets comments

### DIFF
--- a/twitterQL/src/db/config/database.ts
+++ b/twitterQL/src/db/config/database.ts
@@ -14,4 +14,6 @@ const sequelize = new Sequelize(
 
 const Database: any = { sequelize: sequelize };
 
+sequelize.sync;
+
 export default Database;

--- a/twitterQL/src/models/comment.ts
+++ b/twitterQL/src/models/comment.ts
@@ -5,11 +5,19 @@ import Database from '../db/config/database';
 interface CommentAttributes {
   id: number;
   comment: string;
+  createdAt: Date;
+  updatedAt: Date;
+  user_id: string;
+  tweet_id: number;
 }
 
 class Comment extends Model<CommentAttributes> implements CommentAttributes {
   id!: number;
   comment!: string;
+  createdAt: Date;
+  updatedAt: Date;
+  user_id: string;
+  tweet_id: number;
 }
 
 const comment = {

--- a/twitterQL/src/models/tweet.ts
+++ b/twitterQL/src/models/tweet.ts
@@ -5,11 +5,17 @@ import Database from '../db/config/database';
 interface TweetAttributes {
   id: number;
   text: string;
+  createdAt: Date;
+  updatedAt: Date;
+  user_id: string;
 }
 
 class Tweet extends Model<TweetAttributes> implements TweetAttributes {
   id!: number;
   text!: string;
+  createdAt: Date;
+  updatedAt: Date;
+  user_id: string;
 }
 
 const tweet = {

--- a/twitterQL/src/resolvers/comment.ts
+++ b/twitterQL/src/resolvers/comment.ts
@@ -1,0 +1,15 @@
+import User from '../models/user';
+import Tweet from '../models/tweet';
+import Comment from '../models/comment';
+
+export default {
+  user: async (comment: Comment) => {
+    const user = await User.findByPk(comment.user_id, { raw: true });
+    return user;
+  },
+
+  tweet: async (comment: Comment) => {
+    const tweet = await Tweet.findByPk(comment.tweet_id, { raw: true });
+    return tweet;
+  },
+};

--- a/twitterQL/src/resolvers/index.ts
+++ b/twitterQL/src/resolvers/index.ts
@@ -1,10 +1,15 @@
 import QueryResolver from './query';
-
+import UserResolver from './user';
+import TweetResolver from './tweet';
+import CommentResolver from './comment';
 import Date from '../customScalars/dates';
 
 const Resolvers = {
   Query: QueryResolver,
   Date: Date.dateResolver,
+  User: UserResolver,
+  Tweet: TweetResolver,
+  Comment: CommentResolver,
 };
 
 export default Resolvers;

--- a/twitterQL/src/resolvers/query.ts
+++ b/twitterQL/src/resolvers/query.ts
@@ -5,6 +5,7 @@ import Comment from '../models/comment';
 export default {
   users: async () => {
     const users = await User.findAll({ raw: true });
+    console.log(users);
     return users;
   },
 
@@ -15,6 +16,22 @@ export default {
 
   comments: async () => {
     const comments = await Comment.findAll({ raw: true });
+    return comments;
+  },
+
+  user: async (_: any, data: any) => {
+    const users = await User.findByPk(data.id, { raw: true });
+    console.log(users);
+    return users;
+  },
+
+  tweet: async (_: any, data: any) => {
+    const tweets = await Tweet.findByPk(data.id, { raw: true });
+    return tweets;
+  },
+
+  comment: async (_: any, data: any) => {
+    const comments = await Comment.findByPk(data.id, { raw: true });
     return comments;
   },
 };

--- a/twitterQL/src/resolvers/query.ts
+++ b/twitterQL/src/resolvers/query.ts
@@ -5,7 +5,6 @@ import Comment from '../models/comment';
 export default {
   users: async () => {
     const users = await User.findAll({ raw: true });
-    console.log(users);
     return users;
   },
 
@@ -21,7 +20,6 @@ export default {
 
   user: async (_: any, data: any) => {
     const users = await User.findByPk(data.id, { raw: true });
-    console.log(users);
     return users;
   },
 

--- a/twitterQL/src/resolvers/tweet.ts
+++ b/twitterQL/src/resolvers/tweet.ts
@@ -1,0 +1,21 @@
+import User from '../models/user';
+import Tweet from '../models/tweet';
+import Comment from '../models/comment';
+
+export default {
+  user: async (tweet: Tweet) => {
+    console.log('DSAdasadsadsd');
+    const user = await User.findByPk(tweet.user_id, { raw: true });
+    console.log(user);
+    console.log('dasdasadsdasadsads');
+    return user;
+  },
+
+  comments: async (tweet: Tweet) => {
+    const comments = await Comment.findAll({
+      where: { tweet_id: tweet.id },
+      raw: true,
+    });
+    return comments;
+  },
+};

--- a/twitterQL/src/resolvers/tweet.ts
+++ b/twitterQL/src/resolvers/tweet.ts
@@ -4,10 +4,7 @@ import Comment from '../models/comment';
 
 export default {
   user: async (tweet: Tweet) => {
-    console.log('DSAdasadsadsd');
     const user = await User.findByPk(tweet.user_id, { raw: true });
-    console.log(user);
-    console.log('dasdasadsdasadsads');
     return user;
   },
 

--- a/twitterQL/src/resolvers/user.ts
+++ b/twitterQL/src/resolvers/user.ts
@@ -1,0 +1,21 @@
+import User from '../models/user';
+import Tweet from '../models/tweet';
+import Comment from '../models/comment';
+
+export default {
+  tweets: async (user: User) => {
+    const tweets = await Tweet.findAll({
+      where: { user_id: user.id },
+      raw: true,
+    });
+    return tweets;
+  },
+
+  comments: async (user: User) => {
+    const comments = await Comment.findAll({
+      where: { user_id: user.id },
+      raw: true,
+    });
+    return comments;
+  },
+};

--- a/twitterQL/src/types/comment.ts
+++ b/twitterQL/src/types/comment.ts
@@ -8,5 +8,7 @@ export default gql`
     comment: String!
     createdAt: Date
     updatedAt: Date
+    tweet: Tweet
+    user: User
   }
 `;

--- a/twitterQL/src/types/query.ts
+++ b/twitterQL/src/types/query.ts
@@ -5,5 +5,8 @@ export default gql`
     users: [User]
     tweets: [Tweet]
     comments: [Comment]
+    user(id: String!): User
+    comment(id: Int!): Comment
+    tweet(id: Int!): Tweet
   }
 `;

--- a/twitterQL/src/types/query.ts
+++ b/twitterQL/src/types/query.ts
@@ -5,8 +5,8 @@ export default gql`
     users: [User]
     tweets: [Tweet]
     comments: [Comment]
-    user(id: String!): User
-    comment(id: Int!): Comment
-    tweet(id: Int!): Tweet
+    user(userId: String!): User
+    comment(commentId: Int!): Comment
+    tweet(tweetId: Int!): Tweet
   }
 `;

--- a/twitterQL/src/types/tweet.ts
+++ b/twitterQL/src/types/tweet.ts
@@ -7,5 +7,7 @@ export default gql`
     text: String!
     createdAt: Date
     updatedAt: Date
+    user: User
+    comments: [Comment]
   }
 `;

--- a/twitterQL/src/types/user.ts
+++ b/twitterQL/src/types/user.ts
@@ -6,7 +6,9 @@ export default gql`
     name: String!
     surname: String!
     email: String!
-    createdAt: Date
-    updatedAt: Date
+    createdAt: String
+    updatedAt: String
+    comments: [Comment]
+    tweets: [Tweet]
   }
 `;

--- a/twitterQL/src/types/user.ts
+++ b/twitterQL/src/types/user.ts
@@ -6,8 +6,8 @@ export default gql`
     name: String!
     surname: String!
     email: String!
-    createdAt: String
-    updatedAt: String
+    createdAt: Date
+    updatedAt: Date
     comments: [Comment]
     tweets: [Tweet]
   }


### PR DESCRIPTION
Changes: 

1) Extended already define types, as an example, the following field was introduced into the User type:

type User {
    ....
    tweets: [Tweet]
}

This way, graphQL now knows that a user "has many" tweets, and consequently, now, given a user you can query for the tweets of that user.

2) Created resolvers for resolving each field that was added to the types.

3) Also extended the query type so now you can query for an specific user/tweet/comment

3)Introduced a custom DateType as well as its resolvers in order to properly serve dates to clients.

Learnings: GraphQL doesn't have built in support for managing Dates, so it automatically converts any date into a timestamp before serving the response to the client. In order to solve this issue, a custom DateType must be defined as well as its resolvers.